### PR TITLE
Fix sign of D matrix elements when Ra = 0

### DIFF
--- a/WignerDMatrices.md
+++ b/WignerDMatrices.md
@@ -81,7 +81,7 @@ $\mathfrak{D}$ matrix is
   \label{eq:D\_RaApprox0}
   \mathfrak{D}^{(\ell)}\_{m',m}(\quat{R})
   = (-1)^{\ell+m'}\, \quat{R}\_b^{-2m'} \delta\_{-m',m}
-  = (-1)^{\ell+m}\, \quat{R}\_b^{2m} \delta\_{-m',m}.
+  = (-1)^{\ell-m}\, \quat{R}\_b^{2m} \delta\_{-m',m}.
 \end{equation}
 In the same way, we can calculate this for $\lvert \quat{R}_b \rvert
 \lesssim 10^{-15}$:


### PR DESCRIPTION
The final simplification in equation (3) of the "Wigner D matrices"
page introduced an error by exchanging m' for m when the Kronecker
delta indicates that m' should be exchanged for -m. This fixes the
error and brings the documentation into agreement with the behavior
of `spherical_functions.Wigner_D_element`.